### PR TITLE
Feature/zen 24152

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ import os
 from setuptools import setup, find_packages, Extension
 
 setup(name='Acquisition',
-      version = '2.13.8',
+      version = '2.13.8.1',
       url='http://pypi.python.org/pypi/Acquisition',
       license='ZPL 2.1',
       description="Acquisition is a mechanism that allows objects to obtain "


### PR DESCRIPTION
Allow sub-classing of the acquisition wrappers.  See also 
https://github.com/zenoss/zenoss-prodbin/pull/1831
